### PR TITLE
Add documentation for use on stealjs.com

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp/
 node_modules/
 dist/
 .DS_Store
+doc/

--- a/README.md
+++ b/README.md
@@ -10,35 +10,122 @@
 npm install grunt-steal --save-dev
 ```
 
-## Use
+- <code>[__grunt-steal__ Object](#grunt-steal-object)</code>
+  - <code>[steal-build Object](#steal-build-object)</code>
+  - <code>[steal-export Object](#steal-export-object)</code>
+  - <code>[steal-live-reload Object](#steal-live-reload-object)</code>
 
-In your `Gruntfile.js` add tasks for "steal-build" like:
+## API
 
-```js
-grunt.initConfig({
-  "steal-build": {
-    default: {
-      options: {
-        system: {
-          config: __dirname + "/app/config.js",
-          main: "app/app"
-        },
-        buildOptions: {
-          minify: false
-        }
+##  `{Object}`
+
+ 
+**grunt-steal** is a collection of [Grunt](http://gruntjs.com/) tasks for building out projects that use StealJS.
+
+
+
+
+### <code>Object</code>
+
+- __build__ <code>{[steal-build](#steal-build-object)}</code>:
+  
+  
+  A task for building an application for production. Equivalent to using [steal-tools.build].
+  
+- __export__ <code>{[steal-export](#steal-export-object)}</code>:
+  
+  
+  A task for exporting a project to another module format, for sharing with others who will use your project outside of StealJS.
+  
+- __live-reload__ <code>{[steal-live-reload](#steal-live-reload-object)}</code>:
+  
+  
+  A task for starting a [live-reload] server.
+  
+### steal-build `{Object}`
+
+
+The `steal-build` options object's values.
+
+
+
+#### <code>Object</code>
+
+- __steal__ <code>{Object}</code>:
+  Specifies the `config` argument in
+  [steal-tools.build]. The [config.main main] option must be specified. Typically,
+  [config.configPath configPath] is also specified, as that is used to set 
+  [config.baseURL baseURL].  Any Steal [config.config configuration] can be specified; however,
+  most other __build__ configuration values are specified
+  by [config.buildConfig], in the config file.
+  
+- __buildOptions__ <code>{Object}</code>:
+  Specifies the `options` argument 
+  to [steal-tools.build stealTools.build].
+  
+  
+### steal-export `{Object}`
+
+
+A Grunt multi task that loads modules, and writes them out in different formats.
+
+
+
+#### <code>Object</code>
+
+- __tasks__ <code>{Object\<String,steal-tools.export.object\>}</code>:
+  An object with task names as keys,
+  and exportObjects as values.
+  
+  ```
+  grunt.initConfig({
+    "steal-export": {
+      taskName1: { ExportObject1 },
+      taskName2: { ExportObject2 }
+    }
+  });
+  ```
+  
+  Each [steal-tools.export.object] specifies:
+  
+   - A `steal` object that specifies the modules to be loaded.
+   - An `options` object that specifies any special loading behavior, like turning logging.
+   - An `outputs` object that specifies how the modules should be written out.
+   
+  ```
+  grunt.initConfig({
+    "steal-export": {
+      taskName: {
+        steal : { .. },
+        options: { .. },
+        outputs: { .. }
       }
     }
-  }
-});
-```
+  });
+  ```
+  
+  
+### steal-live-reload `{Object}`
 
-Then run with:
 
-```
-grunt steal-build
-```
+The `steal-live-reload` options object's values.
 
-See [stealjs.com](http://stealjs.com/) for documentation on [build](http://stealjs.com/docs/steal-tools.cmd.build.html), [export](http://stealjs.com/docs/steal-tools.grunt.export.html), and [live-reload](http://stealjs.com/docs/steal-tools.grunt.live-reload.html).
+
+
+#### <code>Object</code>
+
+- __steal__ <code>{Object}</code>:
+  Specifies the `config` argument in
+  [steal-tools.build]. The [config.main main] option must be specified. Typically,
+  [config.configPath configPath] is also specified, as that is used to set
+  [config.baseURL baseURL].  Any Steal [config.config configuration] can be specified; however,
+  most other __build__ configuration values are specified
+  by [config.buildConfig], in the config file.
+  
+- __liveReloadOptions__ <code>{Object}</code>:
+  Specifies the `options` argument
+  to [steal-tools.cmd.live-reload steal-tools live-reload].
+  
 
 ## License
 

--- a/docs/apis.json
+++ b/docs/apis.json
@@ -1,0 +1,7 @@
+[
+  {"grunt-steal": [
+    "grunt-steal.build",
+    "grunt-steal.export",
+    "grunt-steal.live-reload"
+  ]}
+]

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,63 @@
+@typedef {{}} grunt-steal.build steal-build
+@parent grunt-steal.tasks
+
+The `steal-build` options object's values.
+
+@option {Object} steal Specifies the `config` argument in
+[steal-tools.build]. The [config.main main] option must be specified. Typically,
+[config.configPath configPath] is also specified, as that is used to set 
+[config.baseURL baseURL].  Any Steal [config.config configuration] can be specified; however,
+most other __build__ configuration values are specified
+by [config.buildConfig], in the config file.
+
+@option {Object} buildOptions Specifies the `options` argument 
+to [steal-tools.build stealTools.build].
+
+
+@body
+
+## Use
+
+> Note: The `steal-build` Grunt task calls [steal-tools.build steal-tools.build] 
+internally. This page documents the specifics of the Grunt task. Read
+[steal-tools.build steal-tools.build's documentation] for how to use
+the build in various workflows and detailed information
+on the steal and options arguments.
+
+`"steal-build"` is registered as a Grunt multi-build task. Specify the
+default "steal-build" task options, as follows:
+
+    grunt.initConfig({
+      "steal-build": {
+        default: {
+          options: {
+            steal: {
+              config: __dirname + "/app/config.js",
+              main: "app/app"
+            },
+            buildOptions: {
+              minify: false
+            }
+          }
+        }
+      }
+    });
+
+The Grunt task takes 2 objects as its 
+options: `steal`, and `buildOptions`.
+
+## steal
+
+These are [config.config] values that are used to 
+load modules during the build process. Typically, you will want 
+to specify at least the `config` and `main` options, like so:
+
+    {
+	  config: __dirname + "/config.js",
+      main: ["math/add", "math/subtract"]
+    }
+
+## buildOptions
+
+The `buildOptions` property specifies the properties on the `options`
+argument to [steal-tools.build stealTools.build]. Read more about them on [steal-tools.build stealTools.build].

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,0 +1,116 @@
+@typedef {{}} grunt-steal.export steal-export
+@parent grunt-steal.tasks
+
+A [http://gruntjs.com/ Grunt] multi task that loads modules, and writes them out in different formats.
+
+@option {Object<String,steal-tools.export.object>} tasks An object with task names as keys,
+and exportObjects as values.
+
+```
+grunt.initConfig({
+  "steal-export": {
+    taskName1: { ExportObject1 },
+    taskName2: { ExportObject2 }
+  }
+});
+```
+
+Each [steal-tools.export.object] specifies:
+
+ - A `steal` object that specifies the modules to be loaded.
+ - An `options` object that specifies any special loading behavior, like turning logging.
+ - An `outputs` object that specifies how the modules should be written out.
+ 
+```
+grunt.initConfig({
+  "steal-export": {
+    taskName: {
+      steal : { .. },
+      options: { .. },
+      outputs: { .. }
+    }
+  }
+});
+```
+
+
+@body
+
+## Use
+
+> Note: The `steal-export` Grunt task calls [steal-tools.export steal-tools.export] 
+internally. This page documents the specifics of the Grunt task. Read
+[steal-tools.export steal-tools.export's documentation] for how to use
+the export in various workflows and detailed information
+on the steal and options arguments.
+
+`steal-export` is a Grunt [multi-task](http://gruntjs.com/creating-tasks#multi-tasks) that is 
+used to build library projects to a variety of formats. For example, to load a "main" module and
+transpile it, and all of its dependencies (except jQuery), to AMD and CommonJS with debug output:
+
+    grunt.initConfig({
+      "steal-export": {
+        transpile: {
+          steal: {
+            main: "main",
+            config: __dirname + "/config.js"
+          },
+          options: {
+            debug: true
+          },
+          outputs: {
+            amd: {
+              graphs: ["main"],
+              format: "amd",
+              ignore: ["jquery"]
+            },
+            cjs: {
+              graphs: ["main"],
+              format: "amd",
+              ignore: ["jquery"]
+            }
+          }
+        }
+      }
+    });
+    
+Each [steal-tools.export.object] task is configured by three values:
+
+ - steal - describes the [config.config] values used to load modules; this is passed to [steal-tools.transformImport].
+ - options - configures special behavior of the loader, such as logging.
+ - outputs - configures the modules that should be written out, how they 
+             should be written out, and where they should be written. 
+
+The [steal-tools.export.object] documentation has more information.
+
+## meta.steal.export-helpers
+
+You can add your own export helpers on your Grunt config's 
+`meta.steal.export-helpers` object, as follows:
+
+```
+grunt.initConfig({
+  meta: {
+    steal: {
+      "export-helpers": {
+        "minify": {minify: true}
+      }
+    }
+  },
+  "steal-export": {
+    transpile: {
+      steal: { ... },
+      outputs: {
+        "amd +minify": {
+          format: "amd"
+        }
+      }
+    }
+  }
+})
+```
+
+
+
+
+

--- a/docs/grunt-steal.md
+++ b/docs/grunt-steal.md
@@ -1,0 +1,39 @@
+@module {{}} grunt-steal
+@parent StealJS.ecosystem
+@group grunt-steal.tasks Tasks
+
+@description
+
+**grunt-steal** is a collection of [Grunt](http://gruntjs.com/) tasks for building out projects that use StealJS.
+
+@option {grunt-steal.build} build
+
+A task for building an application for production. Equivalent to using [steal-tools.build].
+
+@option {grunt-steal.export} export
+
+A task for exporting a project to another module format, for sharing with others who will use your project outside of StealJS.
+
+@option {grunt-steal.live-reload} live-reload
+
+A task for starting a [live-reload] server.
+
+@body
+
+## Installation
+
+Use grunt-steal by first installing it as a development dependency:
+
+```
+> npm install grunt-steal --save-dev
+```
+
+## Use
+
+In your *Gruntfile.js* load the tasks that grunt-steal provides in the same way you register any other Grunt tasks:
+
+```js
+grunt.loadNpmTasks("grunt-steal");
+```
+
+Then use one of the tasks provided in your Grunt configuration: [grunt-steal.build], [grunt-steal.export], and [grunt-steal.live-reload].

--- a/docs/live-reload.md
+++ b/docs/live-reload.md
@@ -1,0 +1,63 @@
+@typedef {{}} grunt-steal.live-reload steal-live-reload
+@parent grunt-steal.tasks
+
+The `steal-live-reload` options object's values.
+
+@option {Object} steal Specifies the `config` argument in
+[steal-tools.build]. The [config.main main] option must be specified. Typically,
+[config.configPath configPath] is also specified, as that is used to set
+[config.baseURL baseURL].  Any Steal [config.config configuration] can be specified; however,
+most other __build__ configuration values are specified
+by [config.buildConfig], in the config file.
+
+@option {Object} liveReloadOptions Specifies the `options` argument
+to [steal-tools.cmd.live-reload steal-tools live-reload].
+
+@body
+
+## Use
+
+`"steal-live-reload"` is registered as a Grunt multi-build task. Specify the
+default "steal-live-reload" task options, as follows:
+
+    grunt.initConfig({
+      "steal-live-reload": {
+        default: {
+          options: {
+            steal: {
+              config: __dirname + "/app/config.js",
+              main: "app/app"
+            },
+            liveReloadOptions: {
+              liveReloadPort: 8013
+            }
+          }
+        }
+      }
+    });
+
+The Grunt task takes 2 objects as its
+options: `steal`, and `liveReloadOptions`.
+
+## steal
+
+These are [config.config] values that are used to
+load modules during the build process. Typically, you will want
+to specify at least the `config` and `main` options, like so:
+
+    {
+	  config: __dirname + "/config.js",
+      main: ["math/add", "math/subtract"]
+    }
+
+## liveReloadOptions
+
+The `liveReloadOptions` property specifies the properties on the `options`
+argument to [steal-tools.cmd.live-reload steal-tools live-reload].
+
+The following options are available:
+
+ - liveReloadPort <i>{Number}</i>
+
+
+Read more about them on [steal-tools.cmd.live-reload steal-tools live-reload].

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "document": "bit-docs",
     "test": "grunt test"
   },
   "repository": {
@@ -28,9 +29,26 @@
     "steal-tools": "^1.0.0-rc.0"
   },
   "devDependencies": {
+    "bit-docs": "0.0.6",
     "grunt": "~0.4.1",
     "grunt-cli": "^1.2.0",
     "grunt-simple-mocha": "^0.4.1",
     "winston": "^2.2.0"
+  },
+  "bit-docs": {
+    "dependencies": {
+      "bit-docs-glob-finder": "^0.0.5",
+      "bit-docs-dev": "^0.0.3",
+      "bit-docs-js": "^0.0.3",
+      "bit-docs-generate-readme": "^0.0.8"
+    },
+    "glob": {
+      "pattern": "**/*.{js,md}",
+      "ignore": "node_modules/**/*"
+    },
+    "readme": {
+      "apis": "./docs/apis.json"
+    },
+    "parent": "grunt-steal"
   }
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -6,11 +6,11 @@ module.exports = function(grunt){
 		var done = this.async();
 		var options = this.options();
 
-		var system = options.system;
+    var steal = options.steal;
 		var buildOptions = options.buildOptions;
 
 		// Run the build with the provided options
-		var promise = build(system, buildOptions);
+		var promise = build(steal, buildOptions);
 		if(promise.then) {
 			var success = function(){
 				grunt.log.writeln("Build was successful.");

--- a/tasks/export.js
+++ b/tasks/export.js
@@ -6,7 +6,7 @@ module.exports = function(grunt){
 		var done = this.async();
 		var options = this.data;
 		// make sure things look right
-		["system","outputs"].forEach(function(name){
+		["steal","outputs"].forEach(function(name){
 			if(!options[name]) {
 				grunt.fail.warn("steal-export needs a "+name+" property.");
 			}

--- a/tasks/live-reload.js
+++ b/tasks/live-reload.js
@@ -5,10 +5,10 @@ module.exports = function(grunt){
 	grunt.registerMultiTask("steal-live-reload", "Start live-reload server.", function(){
 		var options = this.options();
 
-		var system = options.system;
+		var steal = options.steal;
 		var liveReloadOptions = options.liveReloadOptions || {};
 
-		liveReload(system, liveReloadOptions);
+		liveReload(steal, liveReloadOptions);
 	});
 
 };

--- a/test/steal_build.js
+++ b/test/steal_build.js
@@ -18,7 +18,7 @@ describe("steal-build grunt task", function(){
 		registerBuild(grunt);
 
 		grunt.run({
-			system: {
+			steal: {
 				config: __dirname + "/config.js",
 				main: "main"
 			}
@@ -30,7 +30,7 @@ describe("steal-build grunt task", function(){
 		registerBuild(grunt);
 
 		grunt.run({
-			system: {
+			steal: {
 				config: __dirname + "/config.js",
 				main: "main_with_error"
 			}


### PR DESCRIPTION
This adds documentation on how to use grunt-steal, that will be part of stealjs.com.